### PR TITLE
feat: add copy link option to social share component

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@
     share: {
        class: "",
        text: "",
-       items: [ "mail", "linkedin", "facebook", "twitter", "whatsapp" ],
+       items: [ "copy", "mail", "linkedin", "facebook", "twitter", "whatsapp" ],
        list: {
         class: "",
        },

--- a/src/templates/components/social/share.twig
+++ b/src/templates/components/social/share.twig
@@ -8,7 +8,7 @@
 {% set entry = entry ?? null %}
 {% set text = text ?? theme.social.share.text ?? ('social.share'|t) %}
 {% set items = items ?? theme.social.share.items
-  ?? ['mail', 'linkedin', 'facebook', 'twitter', 'whatsapp']
+  ?? ['copy', 'mail', 'linkedin', 'facebook', 'twitter', 'whatsapp']
 %}
 
 {# Define the mapping for each social network #}
@@ -30,7 +30,8 @@
     href: 'https://x.com/intent/post?text=' ~ (entry.title|url_encode) ~ '&url='
       ~ (entry.url|url_encode),
     icon: 'fa-brands fa-x-twitter'
-  }
+  },
+  copy: { icon: 'fa-regular fa-link' }
 } %}
 
 {# Component #}
@@ -41,17 +42,33 @@
     <ul class="{{ theme.social.share.list.class ?? 'flex flex-wrap items-center gap-2' }}">
       {% for item in items|filter(item => socialMap[item] is defined) %}
         <li>
-          <a
-            href="{{ socialMap[item].href }}"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="{{
-            theme.social.share.item.class
-              ?? 'flex h-8 w-8 items-center justify-center'
-            }}"
-          >
-            <i class="{{ socialMap[item].icon }}"></i>
-          </a>
+          {% if item == 'copy' %}
+            <button
+              type="button"
+              x-data="{ copied: false }"
+              @click="navigator.clipboard.writeText('{{ entry.url }}'); copied = true; setTimeout(() => copied = false, 2000)"
+              :aria-label="copied ? '{{ 'social.copied'|t('_craft-twig-components') }}' : '{{ 'social.copy'|t('_craft-twig-components') }}'"
+              class="{{
+              theme.social.share.item.class
+                ?? 'flex h-8 w-8 items-center justify-center'
+              }}"
+            >
+              <i class="{{ socialMap[item].icon }}" x-show="!copied"></i>
+              <i class="fa-solid fa-check" x-show="copied" x-cloak></i>
+            </button>
+          {% else %}
+            <a
+              href="{{ socialMap[item].href }}"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="{{
+              theme.social.share.item.class
+                ?? 'flex h-8 w-8 items-center justify-center'
+              }}"
+            >
+              <i class="{{ socialMap[item].icon }}"></i>
+            </a>
+          {% endif %}
         </li>
       {% endfor %}
     </ul>

--- a/src/translations/de/_craft-twig-components.php
+++ b/src/translations/de/_craft-twig-components.php
@@ -9,4 +9,7 @@ return array (
 
     'consent.type.video' => 'das Video anzusehen',
     'consent.type.form' => 'das Formular abzusenden',
+
+    'social.copy' => 'Link kopieren',
+    'social.copied' => 'Link kopiert',
 );

--- a/src/translations/en/_craft-twig-components.php
+++ b/src/translations/en/_craft-twig-components.php
@@ -9,4 +9,7 @@ return array (
 
     'consent.type.video' => 'view the video',
     'consent.type.form' => 'send the form',
+
+    'social.copy' => 'Copy link',
+    'social.copied' => 'Link copied',
 );

--- a/src/translations/fr/_craft-twig-components.php
+++ b/src/translations/fr/_craft-twig-components.php
@@ -9,4 +9,7 @@ return array (
 
     'consent.type.video' => 'voir la vidéo',
     'consent.type.form' => 'envoyer le formulaire',
+
+    'social.copy' => 'Copier le lien',
+    'social.copied' => 'Lien copié',
 );

--- a/src/translations/nl/_craft-twig-components.php
+++ b/src/translations/nl/_craft-twig-components.php
@@ -9,4 +9,7 @@ return array (
 
     'consent.type.video' => 'de video te bekijken',
     'consent.type.form' => 'het formulier te versturen',
+
+    'social.copy' => 'Link kopiëren',
+    'social.copied' => 'Link gekopieerd',
 );


### PR DESCRIPTION
## Summary

Adds a "copy link" option to the social `share.twig` component that copies the current `entry.url` to the clipboard.

## Changes

- **`share.twig`**: Added `copy` to the default `items` (first in the list) and to `socialMap` (icon only — no `href`). The loop now renders the `copy` item as a `<button>` instead of an `<a>`:
  - `@click` uses `navigator.clipboard.writeText(entry.url)` to copy the link.
  - An Alpine `copied` state swaps the link icon for a checkmark for 2s as confirmation.
  - `:aria-label` toggles between `social.copy` / `social.copied`.
- **Translations**: Added `social.copy` / `social.copied` to the `_craft-twig-components` category for `en`, `nl`, `de`, `fr`.

## Notes

- Relies on **Alpine.js** (consistent with `modal.twig` / `collapse.twig`) and `navigator.clipboard`, which requires a secure context (HTTPS or localhost).
- Still fully configurable — `copy` can be reordered or removed via `theme.social.share.items` or a passed-in `items` prop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)