### PR TITLE
fix(consent): move cookiebot class to wrapper so overlay can hide

### DIFF
--- a/src/templates/components/consent/default.twig
+++ b/src/templates/components/consent/default.twig
@@ -3,19 +3,25 @@
 {% set type = type ?? 'form' %}
 {% set typeMessage = typeMessage ?? null %}
 
-<div class="cookieconsent-optout-{{ consentType }} {{ class }} z-99">
-  <div>
-    {% set link_html = '<a class="underline" href="javascript:Cookiebot.renew()">'
-      ~ (('consent.accept.' ~ consentType)|t('_craft-twig-components'))
-      ~ '</a>'
-    %}
-    {{
-      'consent.accept.message'
-        |t(
-          '_craft-twig-components',
-          { button: link_html|raw, type: (typeMessage ?? ('consent.type.' ~ type))|t('_craft-twig-components') }
-        )
-        |raw
-    }}
+{# Cookiebot toggles `display` on the .cookieconsent-optout-* element to show/hide
+   it, so the layout/centering classes must live on a separate inner element —
+   otherwise Cookiebot's display override fights the flex layout (and forcing the
+   layout back with !important would prevent it from ever being hidden). #}
+<div class="cookieconsent-optout-{{ consentType }}">
+  <div class="{{ class }} z-99">
+    <div>
+      {% set link_html = '<a class="underline" href="javascript:Cookiebot.renew()">'
+        ~ (('consent.accept.' ~ consentType)|t('_craft-twig-components'))
+        ~ '</a>'
+      %}
+      {{
+        'consent.accept.message'
+          |t(
+            '_craft-twig-components',
+            { button: link_html|raw, type: (typeMessage ?? ('consent.type.' ~ type))|t('_craft-twig-components') }
+          )
+          |raw
+      }}
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## Problem

The video cookie-consent overlay had two related issues:

1. **Centering broke.** Cookiebot injects `.cookieconsent-optout-* { display: initial }` to show the notice, which overrode the `flex` on the same element, dropping the message to the top-left.
2. **Forcing `display` broke hiding.** Compensating with `display: flex !important` beat Cookiebot's `display: none`, so the notice could never be hidden once consent was granted.

Root cause: the `cookieconsent-optout-*` class (whose `display` Cookiebot owns) and the layout/centering classes lived on the **same** element.

## Fix

Split them across two elements:

- Outer `<div class="cookieconsent-optout-{{ consentType }}">` — Cookiebot fully owns its `display` (show/hide).
- Inner `<div class="{{ class }} z-99">` — carries the passed layout/centering classes, untouched by Cookiebot.

Centering now works while consent is pending, and the overlay disappears cleanly once consent is given.

🤖 Generated with [Claude Code](https://claude.com/claude-code)