### PR TITLE
fix(video): cookie-block and show consent for all embedded providers

### DIFF
--- a/src/templates/components/ui/video.twig
+++ b/src/templates/components/ui/video.twig
@@ -30,12 +30,8 @@
 
         <iframe
           class="absolute inset-0 h-full w-full"
-          {% if embeddedAsset.providerName in ['YouTube'] %}
-            data-cookieblock-src="{{ embeddedAsset.getIframeSrc(videoOptions) }}"
-            data-cookieconsent="{{ consentType }}"
-          {% else %}
-            src="{{ embeddedAsset.getIframeSrc(videoOptions) }}"
-          {% endif %}
+          data-cookieblock-src="{{ embeddedAsset.getIframeSrc(videoOptions) }}"
+          data-cookieconsent="{{ consentType }}"
           allowfullscreen
         ></iframe>
 
@@ -47,7 +43,7 @@
       <div class="relative ui-video__iframe--js {{ class }}  {{ theme.ui.video.lightbox.class ?? '' }}">
         {{ _self.image(image, imageTransform, video) }}
 
-        <a href="{{ embeddedAsset.getIframeSrc(videoOptions) }}" data-pswp-type="iframe" data-pswp-iframe-url="{{ embeddedAsset.getIframeSrc(videoOptions) }}" aria-label="{{ 'aria.video.play' | t}}" class="{% if embeddedAsset.providerName in ['YouTube'] %}cookieconsent-optin-{{ consentType }}{% endif %} absolute top-1/2 start-1/2 -translate-1/2 {{ theme.ui.video.lightbox.button.class ?? '' }}">
+        <a href="{{ embeddedAsset.getIframeSrc(videoOptions) }}" data-pswp-type="iframe" data-pswp-iframe-url="{{ embeddedAsset.getIframeSrc(videoOptions) }}" aria-label="{{ 'aria.video.play' | t}}" class="cookieconsent-optin-{{ consentType }} absolute top-1/2 start-1/2 -translate-1/2 {{ theme.ui.video.lightbox.button.class ?? '' }}">
           {{ theme.ui.video.lightbox is defined and theme.ui.video.lightbox.button.html ? (theme.ui.video.lightbox.button.html | raw) : '<i class="fa-solid fa-play"></i>' }}
         </a>
 
@@ -105,8 +101,6 @@
 {% endmacro %}
 
 {% macro consent (embeddedAsset, consentType, theme) %}
-  {% if embeddedAsset.providerName in ['YouTube'] %}
-    {% set class = "absolute inset-0 h-full w-full flex justify-center items-center " ~ theme.ui.video.consent.class ?? '' %}
-    <x-consent.default class="{{ class }}" consentType="{{ consentType }}" type="video"></x-consent.default>
-  {% endif %}
+  {% set class = "absolute inset-0 h-full w-full flex justify-center items-center " ~ theme.ui.video.consent.class ?? '' %}
+  <x-consent.default class="{{ class }}" consentType="{{ consentType }}" type="video"></x-consent.default>
 {% endmacro %}


### PR DESCRIPTION
## Problem

The `ui/video` component (used by regular video blocks) gated all cookie-consent handling to `providerName in ['YouTube']`. For **Vimeo** (and any other embedded provider) the `{% else %}` branch loaded the iframe directly via `src`, so **no cookie-block and no consent overlay** rendered.

This is inconsistent with `ui/video/background`, which already applies cookie-blocking and the consent overlay to **all** embedded providers — so a Vimeo background hero shows the consent layer while the same Vimeo video in a standard block does not.

## Fix — mirror `video/background` behaviour

1. **Embed iframe** — always uses `data-cookieblock-src` + `data-cookieconsent` (removed the YouTube-only `if/else`).
2. **Consent overlay macro** — renders `<x-consent.default>` for every embedded provider (removed the YouTube gate).
3. **Lightbox play button** — carries `cookieconsent-optin-{{ consentType }}` unconditionally, so it stays hidden until consent is given.

Twig-only change — no asset rebuild required. Hosted mp4/webm and non-embedded paths are unaffected.

## Testing

- Vimeo video in a standard video block now cookie-blocks the iframe and shows the consent overlay, matching the background component.
- YouTube behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)