### PR TITLE
fix(video/background): contain consent overlay z-index within the background

### DIFF
--- a/src/templates/components/ui/video/background.twig
+++ b/src/templates/components/ui/video/background.twig
@@ -14,7 +14,7 @@
 {% if video is not empty %}
   {% set embeddedAsset = craft.embeddedAssets.get(video) %}
   {% if video.kind is defined and video.kind == 'video' and embeddedAsset is empty %}
-    <div class="absolute inset-0 h-full w-full overflow-hidden {{ class }}">
+    <div class="absolute inset-0 z-0 h-full w-full overflow-hidden {{ class }}">
       <video
         class="absolute inset-0 h-full w-full object-cover"
         aria-hidden="true"
@@ -28,7 +28,7 @@
     </div>
   {% elseif embeddedAsset is not empty %}
     {% set image = image is empty ? embeddedAsset.image : image %}
-    <div class="absolute inset-0 h-full w-full overflow-hidden {{ class }}">
+    <div class="absolute inset-0 z-0 h-full w-full overflow-hidden {{ class }}">
       {{ _self.image(image, imageTransform, video) }}
 
       {% if videoOptions is empty %}


### PR DESCRIPTION
## Problem

When `ui/video/background` is used as a hero background, its consent overlay (`z-99`) paints **on top of the page content**, making titles/buttons unclickable.

**Why:** the background's outer wrapper is `position: absolute` with `z-index: auto`, which does **not** establish a stacking context. So the inner consent overlay's `z-99` is not contained — it bubbles up and competes directly with sibling content (e.g. a hero content block at `z-10`). `99 > 10`, so the consent overlay wins and blocks interaction.

## Fix

Add `z-0` to the background wrapper. `z-index: 0` on a positioned element **does** establish a stacking context (unlike `auto`), so:

- the `z-99` consent overlay is now contained within the background, and
- the whole background sits at level 0 — below any positive-z-index page content.

Hero content at `z-10` now renders above the background and is clickable again. Applied to both wrapper branches (hosted `<video>` and embedded iframe) so the background layer is consistently self-contained.

## Note for consumers

Because the background (including its consent overlay) is now correctly below page content, the consent prompt is no longer interactive where content/overlays sit above it — which is the intended behaviour for a decorative background video. Page-level foreground consent (e.g. Cookiebot banner / renew) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)